### PR TITLE
Anonymized data export

### DIFF
--- a/dbassets/__main__.py
+++ b/dbassets/__main__.py
@@ -156,6 +156,9 @@ def parse_arguments() -> None:
     credential_get_parser.add_argument(
         "-u", "--username", help="Specific username to get credential of."
     )
+    credential_get_parser.add_argument(
+        "-r", "--redacted", help="Hide sensitive credentials"
+    )
 
     # Delete
     credential_delete_parser = delete_subparsers.add_parser(
@@ -265,7 +268,7 @@ def main():
 
     if args.command == "get":
         if args.subcommand == "creds":
-            creds = get_credentials(kp, args.username)
+            creds = get_credentials(kp, args.username, args.redacted)
 
             if args.csv:
                 print(format_into_csv(creds))

--- a/dbassets/__main__.py
+++ b/dbassets/__main__.py
@@ -157,7 +157,7 @@ def parse_arguments() -> None:
         "-u", "--username", help="Specific username to get credential of."
     )
     credential_get_parser.add_argument(
-        "-r", "--redacted", help="Hide sensitive credentials"
+        "-r", "--redacted", action="store_true", help="Hide sensitive credentials"
     )
 
     # Delete

--- a/dbassets/db_api/creds.py
+++ b/dbassets/db_api/creds.py
@@ -25,7 +25,7 @@ def add_credential(
 
 
 def get_credentials(
-    kp: PyKeePass, searched_username: str = ""
+    kp: PyKeePass, redacted: bool, searched_username: str = ""
 ) -> [(str, str, str, str)]:
     array = []
     group = kp.find_groups(name=GROUP_NAME_CREDENTIALS, first=True)
@@ -35,6 +35,10 @@ def get_credentials(
         password = entry.password
         hash = entry.get_custom_property(EXEGOL_DB_HASH_PROPERTY)
         domain = entry.get_custom_property(EXEGOL_DB_DOMAIN_PROPERTY)
+
+        if redacted:
+            password = "**********"
+            hash = "**********"
 
         if not username:
             username = ""

--- a/dbassets/db_api/creds.py
+++ b/dbassets/db_api/creds.py
@@ -25,7 +25,7 @@ def add_credential(
 
 
 def get_credentials(
-    kp: PyKeePass, redacted: bool, searched_username: str = ""
+    kp: PyKeePass, searched_username: str = "", redacted: bool = "false"
 ) -> [(str, str, str, str)]:
     array = []
     group = kp.find_groups(name=GROUP_NAME_CREDENTIALS, first=True)


### PR DESCRIPTION
Hey !

This PR adds the `-r` / `--redacted` flag to the `get` command to **hide sensitive information** (`passwords / hashes`). This can be really useful for exporting data in an audit report to anonymize passwords.

```bash
> db-assets get creds -u Administrator --json | jq .
[
  {
    "username": "Administrator",
    "password": "",
    "hash": "7a8d4e04986afa8ed4060f75e5",
    "domain": "sequel.htb"
  }
]
```

```
> db-assets get creds -u Administrator --json --redacted | jq .
[
  {
    "username": "Administrator",
    "password": "**********",
    "hash": "**********",
    "domain": "sequel.htb"
  }
]
```