### PR TITLE
Fix typo: informations → information in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Exegol-history is a tool to quickly store and retrieve compromised credentials a
 Once an asset is selected from the TUI, the information can be accessed through environment variables and doesn't need to be typed over and over.
 
 ## ✨ Features
-- Add / edit / delete credentials and hosts informations trough a CLI or a TUI
+- Add / edit / delete credentials and hosts information trough a CLI or a TUI
 - Import / export in various format (CSV, Pypykatz, ...)
 - Keybinds customisation
 


### PR DESCRIPTION
Fixed grammatical error where "informations" should be "information" (information is uncountable in English)