### PR TITLE
Add all subcommand for unset

### DIFF
--- a/exegol_history/cli/arguments.py
+++ b/exegol_history/cli/arguments.py
@@ -13,6 +13,7 @@ from exegol_history.cli.functions import (
     UNSET_SUBCOMMAND,
     VERSION_SUBCOMMAND,
     SYNC_SUBCOMMAND,
+    ALL_SUBCOMMAND,
 )
 from exegol_history.cli.utils import check_delimiter
 from exegol_history.db_api.exporting import CredsExportFileType, HostsExportFileType
@@ -72,7 +73,12 @@ def unset_subparser(subparsers):
         HOSTS_SUBCOMMAND,
         help="Unset hosts variables.",
     )
-
+    
+    # All
+    unset_subparsers.add_parser(
+        ALL_SUBCOMMAND,
+        help="Unset all variables (creds and hosts)"
+    (
 
 def add_subparser(subparsers):
     add_parser = subparsers.add_parser(

--- a/exegol_history/cli/arguments.py
+++ b/exegol_history/cli/arguments.py
@@ -77,7 +77,7 @@ def unset_subparser(subparsers):
     # All
     unset_subparsers.add_parser(
         ALL_SUBCOMMAND,
-        help="Unset all variables (creds and hosts)"
+        help="Unset all variables (credentials and hosts)"
     (
 
 def add_subparser(subparsers):

--- a/exegol_history/cli/functions.py
+++ b/exegol_history/cli/functions.py
@@ -39,7 +39,7 @@ import importlib.metadata
 
 CREDS_SUBCOMMAND = "creds"
 HOSTS_SUBCOMMAND = "hosts"
-
+ALL_SUBCOMMAND = "all"
 VERSION_SUBCOMMAND = "version"
 ADD_SUBCOMMAND = "add"
 IMPORT_SUBCOMMAND = "import"
@@ -189,15 +189,17 @@ def set_objects(
             sys.exit(0)
 
 
-def unset_objects(args: argparse.Namespace, config: AppConfig):
-    if args.subcommand == CREDS_SUBCOMMAND:
-        write_credential_in_profile(Credential(), config)
-    elif args.subcommand == HOSTS_SUBCOMMAND:
-        write_host_in_profile(Host(), config)
-    else:
-        raise NotImplementedError
+def unset_objects(args: argparse.Namespace, config: dict[str, Any]): 
+    if args.subcommand == CREDS_SUBCOMMAND: 
+        write_credential_in_profile(Credential(), config) 
+    elif args.subcommand == HOSTS_SUBCOMMAND: 
+        write_host_in_profile(Host(), config) 
+    elif args.subcommand == ALL_SUBCOMMAND: 
+        write_credential_in_profile(Credential(), config) 
+        write_host_in_profile(Host(), config) 
+    else: 
+        raise NotImplementedError 
     sys.exit(0)
-
 
 def show_objects(console: Console):
     env_vars = CREDS_VARIABLES + HOSTS_VARIABLES


### PR DESCRIPTION
Hi Exegol team !

As requested in the Discord server, I added the "all" subcommand for unset. This can be used to unset everything directly instead of doing 2 separates commands (exh unset creds && exh unset hosts)

<img width="543" height="197" alt="Capture d’écran 2026-02-11 à 11 45 42" src="https://github.com/user-attachments/assets/842ecd1f-c954-49af-86e8-abf5868ad2d9" />

<img width="653" height="190" alt="Capture d’écran 2026-02-11 à 11 46 54" src="https://github.com/user-attachments/assets/d13d68f6-a571-4f4f-8aed-52e7e22d3310" />

Best regards,

Ranma