### PR TITLE
feat: add remove all

### DIFF
--- a/exegol_history/cli/arguments.py
+++ b/exegol_history/cli/arguments.py
@@ -2,6 +2,7 @@ import argparse
 
 from exegol_history.cli.functions import (
     ADD_SUBCOMMAND,
+    ALL_SUBCOMMAND,
     CREDS_SUBCOMMAND,
     DELETE_SUBCOMMAND,
     EDIT_SUBCOMMAND,
@@ -316,8 +317,15 @@ def delete_subparser(subparsers):
     credential_delete_parser.add_argument(
         "-i",
         "--id",
-        required=True,
+        required=False,
+        default=None,
         help="IDs of the credentials to be deleted, value are separated by a ',', and ranges by a '-', e.g: '5,7,8-18'.",
+    )
+    credential_delete_parser.add_argument(
+        "--all",
+        action="store_true",
+        default=False,
+        help="Delete all credentials from the database.",
     )
 
     # Hosts
@@ -327,8 +335,21 @@ def delete_subparser(subparsers):
     hosts_delete_parser.add_argument(
         "-i",
         "--id",
-        required=True,
+        required=False,
+        default=None,
         help="IDs of the hosts to be deleted, value are separated by a ',', and ranges by a '-', e.g: '5,7,8-18'.",
+    )
+    hosts_delete_parser.add_argument(
+        "--all",
+        action="store_true",
+        default=False,
+        help="Delete all hosts from the database.",
+    )
+
+    # All
+    delete_subparsers.add_parser(
+        ALL_SUBCOMMAND,
+        help="Delete all credentials and hosts from the database.",
     )
 
 

--- a/exegol_history/cli/functions.py
+++ b/exegol_history/cli/functions.py
@@ -12,6 +12,7 @@ from exegol_history.config.config import AppConfig
 from exegol_history.db_api.creds import (
     Credential,
     add_credentials,
+    delete_all_credentials,
     delete_credentials,
     edit_credentials,
     get_credentials,
@@ -20,6 +21,7 @@ from exegol_history.db_api.exporting import export_objects
 from exegol_history.db_api.hosts import (
     Host,
     add_hosts,
+    delete_all_hosts,
     delete_hosts,
     edit_hosts,
     get_hosts,
@@ -39,6 +41,7 @@ import importlib.metadata
 
 CREDS_SUBCOMMAND = "creds"
 HOSTS_SUBCOMMAND = "hosts"
+ALL_SUBCOMMAND = "all"
 
 VERSION_SUBCOMMAND = "version"
 ADD_SUBCOMMAND = "add"
@@ -93,13 +96,27 @@ def add_object(args: argparse.Namespace, engine: Engine, config: AppConfig):
 
 
 def delete_objects(args: argparse.Namespace, engine: Engine, console: Console):
-    ids = parse_ids(args.id)
+    if args.subcommand == ALL_SUBCOMMAND:
+        delete_all_credentials(engine)
+        delete_all_hosts(engine)
+        return
+
+    if not args.all and args.id is None:
+        console.print(console_error(RuntimeError("Provide --id or --all.")))
+        return
 
     try:
-        if args.subcommand == CREDS_SUBCOMMAND:
-            delete_credentials(engine, ids)
-        elif args.subcommand == HOSTS_SUBCOMMAND:
-            delete_hosts(engine, ids)
+        if args.all:
+            if args.subcommand == CREDS_SUBCOMMAND:
+                delete_all_credentials(engine)
+            elif args.subcommand == HOSTS_SUBCOMMAND:
+                delete_all_hosts(engine)
+        else:
+            ids = parse_ids(args.id)
+            if args.subcommand == CREDS_SUBCOMMAND:
+                delete_credentials(engine, ids)
+            elif args.subcommand == HOSTS_SUBCOMMAND:
+                delete_hosts(engine, ids)
     except RuntimeError as e:
         console.print(console_error(e))
 

--- a/exegol_history/db_api/creds.py
+++ b/exegol_history/db_api/creds.py
@@ -131,6 +131,12 @@ def delete_credentials(engine: Engine, credential_ids: list[str] = list()):
         raise RuntimeError(MESSAGE_ID_NOT_EXIST)
 
 
+def delete_all_credentials(engine: Engine):
+    with Session(engine) as session:
+        session.execute(Credential.__table__.delete())
+        session.commit()
+
+
 def edit_credentials(engine: Engine, credentials: list[Credential]):
     with Session(engine) as session:
         try:

--- a/exegol_history/db_api/hosts.py
+++ b/exegol_history/db_api/hosts.py
@@ -104,6 +104,12 @@ def delete_hosts(engine: Engine, host_ids: list[str] = list()):
         raise RuntimeError(MESSAGE_ID_NOT_EXIST)
 
 
+def delete_all_hosts(engine: Engine):
+    with Session(engine) as session:
+        session.execute(Host.__table__.delete())
+        session.commit()
+
+
 def edit_hosts(engine: Engine, hosts: list[Host]):
     with Session(engine) as session:
         try:

--- a/exegol_history/tests/cli_tests/test_delete_credential_cli.py
+++ b/exegol_history/tests/cli_tests/test_delete_credential_cli.py
@@ -10,6 +10,7 @@ from exegol_history.cli.functions import (
 from exegol_history.db_api.creds import (
     Credential,
     add_credentials,
+    delete_all_credentials,
     get_credentials,
 )
 from exegol_history.db_api.utils import MESSAGE_ID_NOT_EXIST, parse_ids
@@ -87,3 +88,25 @@ def test_delete_credential_not_exist(engine: Engine):
 
     assert MESSAGE_ID_NOT_EXIST in console.file.getvalue().replace("\n", "")
     assert len(get_credentials(engine)) == 0
+
+
+def test_delete_all_credentials(engine: Engine):
+    credential1 = Credential(1, username=USERNAME_TEST_VALUE + "2", password=PASSWORD_TEST_VALUE)
+    credential2 = Credential(2, username=USERNAME_TEST_VALUE)
+    add_credentials(engine, [credential1.as_dict(), credential2.as_dict()])
+
+    command_line = f"{DELETE_SUBCOMMAND} {CREDS_SUBCOMMAND} --all".split()
+    args = parse_arguments().parse_args(command_line)
+
+    delete_objects(args, engine, Console(file=io.StringIO()))
+
+    assert get_credentials(engine) == []
+
+
+def test_delete_all_credentials_empty_table(engine: Engine):
+    command_line = f"{DELETE_SUBCOMMAND} {CREDS_SUBCOMMAND} --all".split()
+    args = parse_arguments().parse_args(command_line)
+
+    delete_objects(args, engine, Console(file=io.StringIO()))
+
+    assert get_credentials(engine) == []

--- a/exegol_history/tests/cli_tests/test_delete_host_cli.py
+++ b/exegol_history/tests/cli_tests/test_delete_host_cli.py
@@ -3,15 +3,18 @@ from rich.console import Console
 from sqlalchemy import Engine
 from exegol_history.cli.arguments import parse_arguments
 from exegol_history.cli.functions import (
+    ALL_SUBCOMMAND,
     DELETE_SUBCOMMAND,
     HOSTS_SUBCOMMAND,
     delete_objects,
 )
+from exegol_history.db_api.creds import Credential, add_credentials, get_credentials
 from exegol_history.db_api.hosts import Host, add_hosts, get_hosts
 from exegol_history.db_api.utils import MESSAGE_ID_NOT_EXIST
 from exegol_history.tests.common import (
     HOSTNAME_TEST_VALUE,
     IP_TEST_VALUE,
+    USERNAME_TEST_VALUE,
 )
 
 
@@ -66,3 +69,40 @@ def test_delete_host_not_exist(engine: Engine):
 
     assert MESSAGE_ID_NOT_EXIST in console.file.getvalue().replace("\n", "")
     assert len(get_hosts(engine)) == 0
+
+
+def test_delete_all_hosts(engine: Engine):
+    host1 = Host(1, ip=IP_TEST_VALUE + "2", hostname=HOSTNAME_TEST_VALUE + "2")
+    host2 = Host(2, ip=IP_TEST_VALUE)
+    add_hosts(engine, [host1.as_dict(), host2.as_dict()])
+
+    command_line = f"{DELETE_SUBCOMMAND} {HOSTS_SUBCOMMAND} --all".split()
+    args = parse_arguments().parse_args(command_line)
+
+    delete_objects(args, engine, Console(file=io.StringIO()))
+
+    assert get_hosts(engine) == []
+
+
+def test_delete_all_hosts_empty_table(engine: Engine):
+    command_line = f"{DELETE_SUBCOMMAND} {HOSTS_SUBCOMMAND} --all".split()
+    args = parse_arguments().parse_args(command_line)
+
+    delete_objects(args, engine, Console(file=io.StringIO()))
+
+    assert get_hosts(engine) == []
+
+
+def test_delete_all(engine: Engine):
+    credential = Credential(1, username=USERNAME_TEST_VALUE)
+    host = Host(1, ip=IP_TEST_VALUE)
+    add_credentials(engine, [credential.as_dict()])
+    add_hosts(engine, [host.as_dict()])
+
+    command_line = f"{DELETE_SUBCOMMAND} {ALL_SUBCOMMAND}".split()
+    args = parse_arguments().parse_args(command_line)
+
+    delete_objects(args, engine, Console(file=io.StringIO()))
+
+    assert get_credentials(engine) == []
+    assert get_hosts(engine) == []


### PR DESCRIPTION
 Add rm all subcommand and --all flag to rm

  Adds two new ways to bulk-delete entries:

  - exh rm creds --all / exh rm hosts --all # delete all entries of a given type
  - exh rm all # purge both credentials and hosts in one command